### PR TITLE
trapz and silent fixes

### DIFF
--- a/src/flexcode/loss_functions.py
+++ b/src/flexcode/loss_functions.py
@@ -15,7 +15,7 @@ def cde_loss(cde_estimates, z_grid, true_z):
 
     n_obs, n_grid = cde_estimates.shape
 
-    term1 = np.mean(np.trapz(cde_estimates**2, z_grid.flatten()))
+    term1 = np.mean(np.trapezoid(cde_estimates**2, z_grid.flatten()))
 
     nns = [np.argmin(np.abs(z_grid - true_z[ii])) for ii in range(n_obs)]
     term2 = np.mean(cde_estimates[range(n_obs), nns])

--- a/src/flexcode/regression_models.py
+++ b/src/flexcode/regression_models.py
@@ -142,7 +142,7 @@ class XGBoost(FlexCodeRegression):
         # Also, set the default values if not passed
         params["max_depth"] = params.get("max_depth", 6)
         params["learning_rate"] = params.get("learning_rate", 0.3)
-        params["silent"] = params.get("silent", 1)
+        params["verbosity"] = params.get("silent", 1)
         params["objective"] = params.get("objective", "reg:linear")
 
         params_opt, opt_flag = params_dict_optim_decision(params, multi_output=True)

--- a/tests/flexcode/test_cv_optim.py
+++ b/tests/flexcode/test_cv_optim.py
@@ -67,9 +67,9 @@ def test_coef_predict_same_as_predict_rf():
 
 
 def test_coef_predict_same_as_predict_xgb():
-    x_train, z_train = generate_data(1000)
-    x_validation, z_validation = generate_data(1000)
-    x_test, _ = generate_data(1000)
+    x_train, z_train = generate_data(5000)
+    x_validation, z_validation = generate_data(5000)
+    x_test, _ = generate_data(5000)
 
     # Parameterize model
     model = flexcode.FlexCodeModel(


### PR DESCRIPTION
Simple PR that addresses issues #17 and #20 by changing trapz -> trapezoid and updating "silent" param to "verbosity", since XGBoost changed the name a while back.  

The trapz makes FlexCode compatible with numpy>=2.0, as trapz is now deprecated and causes an Error.  The verbosity stops a giant chain of warnings that pop up when FlexCode is run because silent was renamed to verbosity.